### PR TITLE
SH options, custom display arguments ('ps' and 'vs'), envvars.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,24 @@ run: ${TESTSRCS}
 man: ${TESTSRCS}
 	export GHLENABLECOLOR=1 && ./ghighlight.pl $< | groff -Tascii -w w -ms
 
+# GH_INTRO: instructions before each source code provided by source-highlight
+# GH_OUTRO: ------------ after  ---- ------ ---- -------- -- ----------------
+# GH_INTRO/GH_OUTRO: values are separated by ';'
+
+GH_INTRO = .nr DI 0;.DS I;.fam C
+GH_OUTRO = .fam;.DE
+# export GH_INTRO
+# export GH_OUTRO
+
+# SHOPTS: cmd line parameter given to source-highlight
+SHOPTS = --outlang-def=./my-groff-output.def
+#export SHOPTS
+
+custom:
+	soelim $(TESTSRCS) |\
+		GH_INTRO="$(GH_INTRO)" GH_OUTRO="$(GH_OUTRO)" SHOPTS="$(SHOPTS)" ./ghighlight.pl |\
+		groff -Tpdf -w w -ms > test.pdf
+
 %.pdf: %.ms
 	soelim $< | ./ghighlight.pl | groff -Tpdf -w w -ms > $@
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,40 @@ if you are using ".so"-makros in your files, you must combine the files beforeha
 
 `soelim MAIN.ms | ghighlight | groff -Tpdf > MAIN.pdf`
 
+## Source Arguments
+
+Currently, two instructions are available to customize your code display: `ps` and `vs`.
+
+```roff
+.\" There I change the font size and the spacing between lines.
+.`` c ps=7 vs=9p
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[])
+{
+    printf("hello\n");
+    return 0;
+}
+.``
+```
+
+## Environment variables
+
+* GH_INTRO: troff instructions **before** each source code provided by source-highlight
+* GH_OUTRO: troff instructions **after** each source code provided by source-highlight
+
+Both GH_INTRO and GH_OUTRO: values are separated by ';'.
+
+Example:
+
+`GH_INTRO=".DS I;.fam C" GH_OUTRO=".fam;.DE" ghighlight file.ms | ...`
+
+* SHOPTS: cmd line parameter given to source-highlight
+
+Example:
+
+`SHOPTS="--outlang-def=./my-groff-output.def" ghighlight file.ms | ...`
 
 ## Contributing
 

--- a/ghighlight.pl
+++ b/ghighlight.pl
@@ -29,8 +29,6 @@ use strict;
 use warnings;
 #use diagnostics;
 
-use v5.30;
-
 # temporary dir and files
 use File::Temp qw/ tempfile tempdir /;
 

--- a/my-groff-output.def
+++ b/my-groff-output.def
@@ -1,0 +1,71 @@
+extension "groff"
+doctemplate
+"
+.MT 0
+$header
+.TL 
+$title
+.AU \"\"
+.ND
+.SA 0
+.DS I
+"
+".DE
+$footer
+"
+end
+
+nodoctemplate
+"
+"
+"
+"
+end
+
+bold "\f[CB]$text\fP"
+italics "\f[CI]$text\fP"
+underline "\f[CI]$text\fP"
+fixed "\fC$text\fP"
+color "\m[$style]$text\m[]"
+
+anchor "$infilename : $linenum - $text"
+reference "$text \(-> $infile:$linenum, page : $infilename:$linenum"
+
+#lineprefix "\fC\(em\fP   "
+#lineprefix "\fC\n(ln\fP   "
+
+lineprefix ""
+
+
+colormap
+"green" "green"
+"red" "red"
+"darkred" "darkred"
+"blue" "blue"
+"brown" "brown"
+"pink" "pink"
+"yellow" "yellow"
+"cyan" "cyan"
+"purple" "purple"
+"orange" "orange"
+"brightorange" "brightorange"
+"brightgreen" "brightgreen"
+"darkgreen" "darkgreen"
+"black" "black"
+"teal" "teal"
+"gray" "gray"
+"darkblue" "darkblue"
+default "black"
+end
+
+translations
+"\\" "\\\\"
+##"\n" " \\\\\n"
+##" " "\\ "
+##"\t" "\\ \\ \\ \\ \\ \\ \\ \\ "
+"\t" "    "
+"|" "|"
+"---" "\(em"
+"--" "\(mi"
+end
+

--- a/test.ms
+++ b/test.ms
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
 .LP
 just make sure this prints
 
-.`` c
+.`` c ps=14 vs=16p
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Hello,

this PR adds 3 things:

- source-highlights arguments, so it is now possible to provide a custom groff output definition file, for example.
  I needed that to remove arbitrary decisions made in the original file on my system, which adds `.DS I` and `.fam C` to the generated code.
- environment variables, they are used also to provide a way for users to add custom instructions before each generated code.
 Doing so in the groff output definition file prevents users to further customize an individual code display (see last point).
- finally, the PR adds a way for users to change the font size and the line spacing of each code, separately.
Example:

```troff
.SOURCE Haskell ps=7 vs=9p
fib :: Int -> Int
fib 1 = 1
fib 2 = 1
fib x = fib (x-1) + fib (x-2)
.SOURCE
```

This PR also adds a custom groff output definition file for `source-highlight` and another instruction in the Makefile (`custom`, to test all I just said).

Thanks!